### PR TITLE
Issue: hang in unw_get_proc_name if heap corrupt

### DIFF
--- a/panic.c
+++ b/panic.c
@@ -41,6 +41,7 @@
 static void print(char *str)
 {
     write(STDERR_FILENO, str, strlen(str));
+    fsync(STDERR_FILENO);
 }
 
 #ifdef __LIBUNWIND__
@@ -119,7 +120,9 @@ static void print_backtrace(void)
 
         unw_get_reg(&cursor, UNW_REG_IP, &ip);
         unw_get_reg(&cursor, UNW_REG_SP, &sp);
+        print("The next line hangs\n");
         unw_get_proc_name(&cursor, field, FIELD_SIZE, &offset);
+        print("This line is never printed\n");
 
         snprintf(line, LINE_SIZE, "  %2d: [0x%016" PRIxPTR "] %s+0x%" PRIxPTR " (0x%016" PRIxPTR ")\n", i, ip, field, offset, sp);
         print(line);
@@ -187,9 +190,6 @@ static void panic_handler(int signum, siginfo_t *siginfo, void *ucontext)
 #endif
 
     print("-- PANIC END --\n");
-
-    // This seems to help ensure the trace is fully printed
-    sleep(1);
 }
 
 void install_panic_handler(void)

--- a/server.c
+++ b/server.c
@@ -42,6 +42,34 @@ typedef struct thread_context {
 
 bool visited = false;
 
+#define MALLOC_SMASH
+
+#ifdef MALLOC_SMASH
+
+__attribute__((noinline))
+void crash(char *ptr) {
+    write(STDERR_FILENO, "crash called\n", 13);
+    memset((void *)ptr, 'E', 4096 * 4);
+    write(STDERR_FILENO, "crash return\n", 13);
+}
+
+__attribute__((noinline))
+int inner() {
+    for (int i = 0; i < 10; i++) {
+        char *my_ptr = malloc(32);
+        crash(my_ptr);
+    }
+    return 0;
+}
+
+__attribute__((noinline))
+int outer() {
+    inner();
+    return 0;
+}
+
+#else
+
 __attribute__((noinline))
 void crash(int info) {
     (void) info;
@@ -60,6 +88,7 @@ int outer() {
     inner();
     return 0;
 }
+#endif
 
 void* run(void* data) {
     int sock = ((thread_context_t*) data)->socket;


### PR DESCRIPTION
This is not meant to be merged, but an example of an issue with unw_get_proc_name() when the crash has occurred due to a corrupt heap.